### PR TITLE
Add a docker label to the Dockerfile to link to the source repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:latest
 
+LABEL org.opencontainers.image.source="https://github.com/cam-inc/MxTransporter"
+
 WORKDIR /go/src
 
 COPY . ./


### PR DESCRIPTION
# 概要
Github packageのコンテナレジストリで公開済みの [mx-transporter](https://github.com/orgs/cam-inc/packages/container/package/mx-transporter) とこのレポジトリを紐づけるための修正です

# やったこと
Dockerfileに org.opencontainers.image.source のラベルを追加
参考: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys