### PR TITLE
Add stage for deploy in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:latest
+##
+## Build
+##
+FROM golang:latest as build
 
 WORKDIR /go/src
 
@@ -14,5 +17,16 @@ RUN go install ./cmd/main.go
 
 RUN go build -o /go/bin/health -ldflags '-s -w' ./cmd/health.go
 RUN go install ./cmd/health.go
+
+##
+## Deploy
+##
+FROM alpine:latest
+
+WORKDIR /go/src
+
+COPY --from=build /go/bin/main /go/bin/main
+COPY --from=build /go/bin/health /go/bin/health
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
 
 ENTRYPOINT ["/go/bin/main"]


### PR DESCRIPTION
# 概要
コンテナで実行するimageのサイズを縮小することを目的にDockerfileにデプロイ用のステージを追加しました。
336.73 MB から 2.68 MB ほどになります

# やったこと
実行用のimageはalpineを使用するようにbuild stageを追加しました
参考: https://docs.docker.com/language/golang/build-images/#multi-stage-builds

# 動作確認
Fargate上でコンテナが起動してchange streamが受け取れていることをログで確認しました
コンテナがエラーで停止していないのでKinesisへのexportも成功している判断です
<img width="1447" alt="スクリーンショット 2022-03-31 14 37 10" src="https://user-images.githubusercontent.com/5451362/160984019-6377c361-f1ed-407e-8125-4fc005afa19b.png">

