### PR TITLE
Add handling at cs.next()

### DIFF
--- a/application/export_change_streams_mock.go
+++ b/application/export_change_streams_mock.go
@@ -116,3 +116,7 @@ func (m *mockChangeStreamsExporterClientImpl) saveResumeToken(_ context.Context,
 	m.csCursorFlag = false
 	return nil
 }
+
+func (m *mockChangeStreamsExporterClientImpl) err() error {
+	return nil
+}


### PR DESCRIPTION
ChangeStream.Next()はcursorを受け取らないとfalseを返すので、その際のハンドリング処理を追加しました。
もしcursorを受け取らない場合はエラーになり、全体の処理が異常終了します。

※参考
https://pkg.go.dev/go.mongodb.org/mongo-driver@v1.9.0/mongo#ChangeStream.Next