### PR TITLE
Fix: add pubsub ordering key description

### DIFF
--- a/docs/gcp/gke/README.md
+++ b/docs/gcp/gke/README.md
@@ -34,12 +34,12 @@ EXPORT_DESTINATION=bigquery,pubsub
 ```
 
 ### Pubsub Ordering (optional)
-If you want to order message in pubsub, set ```PUBSUB_ORDERING_BY``` env.
+If you want to order message in pubsub, set ```PUBSUB_ORDERING_BY``` env.<br>
+Specify the field name of one of the Change Streams.<br>
 https://cloud.google.com/pubsub/docs/ordering
 
 **NOTICE**
-ordering message can cause performance issues.
-
+ordering message can cause performance issues.<br>
 see https://medium.com/google-cloud/google-cloud-pub-sub-ordered-delivery-1e4181f60bc8
 
 ### BigQuery schema  (optional)

--- a/docs/gcp/gke/README_JP.md
+++ b/docs/gcp/gke/README_JP.md
@@ -35,7 +35,7 @@ EXPORT_DESTINATION=bigquery,pubsub
 
 ### Pubsub Ordering (オプション)
 メッセージの順序指定を利用したい場合、環境変数```PUBSUB_ORDERING_BY```を設定する必要があります。<br>
-Change Streamsのいずれかのフィールド名を指定しましょう。<br>
+Change Streamsのいずれかのフィールド名を指定します。<br>
 https://cloud.google.com/pubsub/docs/ordering
 
 **注意**

--- a/docs/gcp/gke/README_JP.md
+++ b/docs/gcp/gke/README_JP.md
@@ -34,11 +34,12 @@ EXPORT_DESTINATION=bigquery,pubsub
 ```
 
 ### Pubsub Ordering (オプション)
-メッセージの順序指定を利用したい場合、環境変数```PUBSUB_ORDERING_BY```を設定する必要があります。
+メッセージの順序指定を利用したい場合、環境変数```PUBSUB_ORDERING_BY```を設定する必要があります。<br>
+Change Streamsのいずれかのフィールド名を指定しましょう。<br>
 https://cloud.google.com/pubsub/docs/ordering
 
 **注意**
-メッセージの順序指定はパフォーマンスに悪影響をもたらす可能性があります。
+メッセージの順序指定はパフォーマンスに影響をもたらす可能性があります。<br>
 参照: https://medium.com/google-cloud/google-cloud-pub-sub-ordered-delivery-1e4181f60bc8
 
 ### BigQuery スキーマ (オプション)

--- a/docs/gcp/gke/helm/templates/stateless.yaml
+++ b/docs/gcp/gke/helm/templates/stateless.yaml
@@ -50,6 +50,18 @@ spec:
 #                secretKeyRef:
 #                  name: {{ $.Values.secrets.name }}
 #                  key: BIGQUERY_TABLE_{{ $collection }}
+#            # Optional
+#            - name: PUBSUB_TOPIC_NAME
+#              valueFrom:
+#                secretKeyRef:
+#                  name: {{ $.Values.secrets.name }}
+#                  key: PUBSUB_TOPIC_NAME{{ $collection }}
+#            # Optional
+#            - name: PUBSUB_ORDERING_BY
+#              valueFrom:
+#                secretKeyRef:
+#                  name: {{ $.Values.secrets.name }}
+#                  key: PUBSUB_ORDERING_BY{{ $collection }}
             - name: RESUME_TOKEN_VOLUME_DIR
               valueFrom:
                 secretKeyRef:

--- a/docs/gcp/gke/secrets.env.template
+++ b/docs/gcp/gke/secrets.env.template
@@ -21,6 +21,8 @@ EXPORT_DESTINATION=
 # Optional
 ## You have to specify this environment variable if you want to export Cloud PubSub.
 PUBSUB_TOPIC_NAME=
+## You have to specify this environment variable if you want to take advantage of PubSub message ordering.
+PUBSUB_ORDERING_BY=
 
 # Require
 ## Specify the time zone you run this middleware by referring to the following. (e.g. TIME_ZONE=Asia/Tokyo)


### PR DESCRIPTION
CLoud Pub/Sub 標準機能である Ordering Key を利用するための説明を加えました。

機能追加のプルリクは↓で、本プルリクで説明を補足しました。
https://github.com/cam-inc/MxTransporter/pull/28