### PR TITLE
Update Go version to 1.26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.1
+          go-version: 1.26.0
 
       - name: Test with coverage
         run: go test --tags=test -coverprofile=cover.out $(go list ./... | grep -v mxtransporter/cmd)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build
 ##
-FROM golang:1.22.1-bookworm as build
+FROM golang:1.26.0-bookworm as build
 
 LABEL org.opencontainers.image.source="https://github.com/cam-inc/MxTransporter"
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-bookworm
+FROM golang:1.26.0-bookworm
 
 WORKDIR /go/src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cam-inc/mxtransporter
 
-go 1.22
+go 1.26.0
 
 require (
 	cloud.google.com/go/bigquery v1.18.0


### PR DESCRIPTION
## Changes

Update Go version from 1.22.1 to 1.26.0 across all configuration files:

- **CI/CD**: Updated GitHub Actions workflow to use Go 1.26.0
- **Docker**: Updated both Dockerfile and Dockerfile.local to use golang:1.26.0-bookworm base image
- **Go Module**: Updated go.mod to specify Go 1.26.0

This ensures consistent Go version usage across development, CI/CD, and containerized environments.