### PR TITLE
update: go version v1.22 -> v1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.22.1
+          go-version: 1.26.0
 
       - name: Test with coverage
         run: go test --tags=test -coverprofile=cover.out $(go list ./... | grep -v mxtransporter/cmd)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: 1.26.0
+          go-version: 1.26.1
 
       - name: Test with coverage
         run: go test --tags=test -coverprofile=cover.out $(go list ./... | grep -v mxtransporter/cmd)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build
 ##
-FROM golang:1.26.1-bookworm as build
+FROM golang:1.26.1-trixie as build
 
 LABEL org.opencontainers.image.source="https://github.com/cam-inc/MxTransporter"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build
 ##
-FROM golang:1.26.0-bookworm as build
+FROM golang:1.26.1-bookworm as build
 
 LABEL org.opencontainers.image.source="https://github.com/cam-inc/MxTransporter"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ##
 ## Build
 ##
-FROM golang:1.22.1-bookworm as build
+FROM golang:1.26.0-bookworm as build
 
 LABEL org.opencontainers.image.source="https://github.com/cam-inc/MxTransporter"
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-bookworm
+FROM golang:1.26.0-bookworm
 
 WORKDIR /go/src
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-bookworm
+FROM golang:1.26.1-bookworm
 
 WORKDIR /go/src
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-bookworm
+FROM golang:1.26.1-trixie
 
 WORKDIR /go/src
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cam-inc/mxtransporter
 
-go 1.26.0
+go 1.26.1
 
 require (
 	cloud.google.com/go/bigquery v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cam-inc/mxtransporter
 
-go 1.22
+go 1.26.0
 
 require (
 	cloud.google.com/go/bigquery v1.18.0


### PR DESCRIPTION
## Summary

Go のバージョンを 1.22 から 1.26.1 へアップグレードします。

## Changes

- `go.mod`: `go 1.22` → `go 1.26.1`
- `Dockerfile`: `golang:1.22.1-bookworm` → `golang:1.26.1-bookworm`
- `Dockerfile.local`: `golang:1.22.1-bookworm` → `golang:1.26.1-bookworm`
- `.github/workflows/ci.yml`: `go-version: 1.22.1` → `go-version: 1.26.1`

## Investigation

Go 1.26 へのアップグレードにあたり、以下のディレクトリ配下のソースコード全体を調査しました。

- `/application`
- `/cmd`
- `/compose`
- `/config`
- `/interfaces`
- `/pkg`
- `/usecases`

調査観点：
- 廃止・削除された標準パッケージの使用（`io/ioutil` 等）
- 非推奨 API の使用
- ビルドタグの形式
- その他 Go 1.23〜1.26 との非互換性

**結果：ソースコードへの修正は不要であることを確認しました。**

## Test plan

- [ ] `go mod tidy` を実行し、依存関係に差分がないことを確認
- [ ] `go build ./...` が成功することを確認
- [ ] `go test --tags=test ./...` が成功することを確認
- [ ] CI が通ることを確認