### PR TITLE
fix: Dockerfile の GOARCH をマルチアーキテクチャビルドに対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ COPY . ./
 
 RUN go mod download
 
+ARG TARGETARCH
 ARG CGO_ENABLED=0
 ARG GOOS=linux
-ARG GOARCH=amd64
+ARG GOARCH=${TARGETARCH}
 
 RUN go build -o /go/bin/main -ldflags '-s -w' ./cmd/main.go
 RUN go install ./cmd/main.go


### PR DESCRIPTION
## 概要

`release.yaml` でマルチアーキテクチャビルド（`linux/amd64`, `linux/arm64`）を設定しているにも関わらず、
`Dockerfile` で `GOARCH=amd64` をハードコードしていたため、arm64 環境向けビルド時にも
amd64 バイナリが生成されてしまう問題を修正しました。

## 変更内容

`Dockerfile` の `GOARCH` を Docker Buildx が自動設定する `TARGETARCH` を参照するように変更しました。